### PR TITLE
Fix typos in docstrings

### DIFF
--- a/code/agent_q_learning/algorithm/algorithm.py
+++ b/code/agent_q_learning/algorithm/algorithm.py
@@ -25,7 +25,7 @@ class Algorithm:
     def learn(self, list_sample_data):
         """
         Update the Q-table with the given game data:
-            - list_sample: each sampple is [state, action, reward, new_state]
+            - list_sample: each sample is [state, action, reward, new_state]
         Using the following formula to update q value:
             - Q(s,a):= Q(s,a) + lr [R(s,a) + gamma * max Q(s',a') - Q(s,a)]
         """

--- a/code/agent_sarsa/algorithm/algorithm.py
+++ b/code/agent_sarsa/algorithm/algorithm.py
@@ -25,7 +25,7 @@ class Algorithm:
     def learn(self, list_sample_data):
         """
         Update the Q-table with the given game data:
-            - list_sample: each sampple is (state, action, reward, next_state, next_action)
+            - list_sample: each sample is (state, action, reward, next_state, next_action)
         Using the following formula to update q value:
             - Q(s,a):= Q(s,a) + lr [R(s,a) + gamma * Q(s',a') - Q(s,a)]
         If next_state is the end, then next_action is -1


### PR DESCRIPTION
## Summary
- fix typo `sampple` to `sample` in Q-learning algorithm docstring
- fix same typo in SARSA algorithm docstring

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6866486e2794832fb8d2e83ab4098ef8